### PR TITLE
Change readme.md to state diagonal screen tearing on hardware is less noticeable

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -7,7 +7,7 @@ A Minecraft-esque game for the TI 84 CE calculator. In it you can generate natur
 ![Screenshot](Screenshot.png)
 
 Some sample gameplay captured in [CEmu](https://ce-programming.github.io/CEmu/). Note that the triangular screen-tearing
-is an artifact of the emulator, and doesn't show up when running on real hardware.
+is an artifact of the emulator, and is less noticeable when running on real hardware.
 
 
 ## Try It Yourself


### PR DESCRIPTION
The diagonal line is an artifact of GraphX using a row-major ordering of pixels in the VRAM instead of column-major ordering. The screen is actually a portrait display, requiring the hardware to flip the screen over the diagonal line, causing minor screen tearing. The only way to fix this is to rewrite GraphX to use the column-major ordering that is native to the display. You can view the same effect using Ndless programs on the TI-Nspire CX II (CAS) because that calculator uses the same display.