### PR TITLE
Change references of the TI 84 CE to TI-84 Plus CE

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,6 @@
-# Blocks for the TI 84 CE
+# Blocks for the TI-84 Plus CE
 
-A Minecraft-esque game for the TI 84 CE calculator. In it you can generate natural-looking worlds, place up to 24 different kinds of blocks, keep up to 5 saves, and enjoy real-time shadow effects, transparent water, and a 10 FPS framerate!
+A Minecraft-esque game for the TI-84 Plus CE calculator. In it you can generate natural-looking worlds, place up to 24 different kinds of blocks, keep up to 5 saves, and enjoy real-time shadow effects, transparent water, and a 10 FPS framerate!
 
  ## Check out [this video](https://www.youtube.com/watch?v=Bj9CiMO66xk) to see it running on real hardware, and for more implementation details.
 
@@ -12,7 +12,7 @@ is an artifact of the emulator, and doesn't show up when running on real hardwar
 
 ## Try It Yourself
 
-**Note:** Due to reliance on some eZ80 hardware instructions, this program can only be run on CE or later model calculators from the Ti84 family.
+**Note:** Due to reliance on some eZ80 hardware instructions, this program can only be run on CE or later model calculators from the TI-84 Plus family.
 
 1. Download the binary [here](bin/BLOCKS.8xp).
 2. Download the [CE C Standard Libraries](https://github.com/CE-Programming/libraries/releases/tag/v11.2).


### PR DESCRIPTION
And the Ti84 family to the TI-84 Plus family

The Ti84 does not exist, and neither does the TI 84 CE.